### PR TITLE
Replace footer background with container-width top border

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -29,7 +29,7 @@ import Link from './Link.astro';
     align-items: center;
     gap: var(--space-tight);
     padding-block: var(--space-layout);
-    border-top: 1px solid var(--border);
+    border-top: 1px solid var(--border-subtle);
   }
 
   .footer-links {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,8 +20,6 @@ import Link from './Link.astro';
 <style is:global>
   footer {
     margin-top: var(--space-section);
-    padding-block: var(--space-layout);
-    background: var(--surface);
   }
 
   .footer-content {
@@ -30,6 +28,8 @@ import Link from './Link.astro';
     justify-content: space-between;
     align-items: center;
     gap: var(--space-tight);
+    padding-block: var(--space-layout);
+    border-top: 1px solid var(--border);
   }
 
   .footer-links {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,16 +20,25 @@ import Link from './Link.astro';
 <style is:global>
   footer {
     margin-top: var(--space-section);
+    container-type: inline-size;
   }
 
   .footer-content {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    flex-direction: column;
     align-items: center;
+    text-align: center;
     gap: var(--space-tight);
     padding-block: var(--space-layout);
     border-top: 1px solid var(--border-subtle);
+  }
+
+  @container (min-width: 400px) {
+    .footer-content {
+      flex-direction: row;
+      justify-content: space-between;
+      text-align: left;
+    }
   }
 
   .footer-links {


### PR DESCRIPTION
- Remove full-width background color from footer
- Add subtle top border to .footer-content
- Border now respects container width instead of spanning full viewport